### PR TITLE
update cohomology interface

### DIFF
--- a/multipers/gudhi/gudhi/Persistence_matrix/base_pairing.h
+++ b/multipers/gudhi/gudhi/Persistence_matrix/base_pairing.h
@@ -132,7 +132,7 @@ inline const typename Base_pairing<Master_matrix>::Barcode& Base_pairing<Master_
 template <class Master_matrix>
 inline void Base_pairing<Master_matrix>::_reduce() 
 {
-  std::unordered_map<ID_index, Index> pivotsToColumn(_matrix()->get_number_of_columns());
+  std::unordered_map<Index, Index> negativeColumns(_matrix()->get_number_of_columns());
 
   auto dim = _matrix()->get_max_dimension();
   std::vector<std::vector<Index> > columnsByDim(dim + 1);
@@ -144,17 +144,21 @@ inline void Base_pairing<Master_matrix>::_reduce()
     for (Index i : cols) {
       auto& curr = _matrix()->get_column(i);
       if (curr.is_empty()) {
-        if (pivotsToColumn.find(i) == pivotsToColumn.end()) {
+        if (negativeColumns.find(i) == negativeColumns.end()) {
           barcode_.emplace_back(i, -1, dim);
         }
       } else {
         ID_index pivot = curr.get_pivot();
+        auto it = idToPosition_.find(pivot);
+        Index pivotColumnNumber = it == idToPosition_.end() ? pivot : it->second;
+        auto itNeg = negativeColumns.find(pivotColumnNumber);
+        Index pivotKiller = itNeg == negativeColumns.end() ? -1 : itNeg->second;
 
-        while (pivot != static_cast<ID_index>(-1) && pivotsToColumn.find(pivot) != pivotsToColumn.end()) {
+        while (pivot != static_cast<ID_index>(-1) && pivotKiller != static_cast<Index>(-1)) {
           if constexpr (Master_matrix::Option_list::is_z2) {
-            curr += _matrix()->get_column(pivotsToColumn.at(pivot));
+            curr += _matrix()->get_column(pivotKiller);
           } else {
-            auto& toadd = _matrix()->get_column(pivotsToColumn.at(pivot));
+            auto& toadd = _matrix()->get_column(pivotKiller);
             typename Master_matrix::Element coef = toadd.get_pivot_value();
             auto& operators = _matrix()->colSettings_->operators;
             coef = operators.get_inverse(coef);
@@ -163,12 +167,14 @@ inline void Base_pairing<Master_matrix>::_reduce()
           }
 
           pivot = curr.get_pivot();
+          it = idToPosition_.find(pivot);
+          pivotColumnNumber = it == idToPosition_.end() ? pivot : it->second;
+          itNeg = negativeColumns.find(pivotColumnNumber);
+          pivotKiller = itNeg == negativeColumns.end() ? -1 : itNeg->second;
         }
 
         if (pivot != static_cast<ID_index>(-1)) {
-          pivotsToColumn.emplace(pivot, i);
-          auto it = idToPosition_.find(pivot);
-          auto pivotColumnNumber = it == idToPosition_.end() ? pivot : it->second;
+          negativeColumns.emplace(pivotColumnNumber, i);
           _matrix()->get_column(pivotColumnNumber).clear();
           barcode_.emplace_back(pivotColumnNumber, i, dim - 1);
         } else {

--- a/multipers/gudhi/gudhi/Persistent_cohomology.h
+++ b/multipers/gudhi/gudhi/Persistent_cohomology.h
@@ -165,7 +165,8 @@ class Persistent_cohomology {
    *
    * Assumes that the filtration provided by the simplicial complex is
    * valid. Undefined behavior otherwise. */
-  void compute_persistent_cohomology(Filtration_value min_interval_length = 0) {
+  void compute_persistent_cohomology(Filtration_value min_interval_length = 0,
+                                     const bool is_simplicial_and_starting_from_dim_0 = true) {
     interval_length_policy.set_length(min_interval_length);
     Simplex_key idx_fil = -1;
     std::vector<Simplex_key> vertices; // so we can check the connected components at the end
@@ -174,16 +175,20 @@ class Persistent_cohomology {
       cpx_->assign_key(sh, ++idx_fil);
       dsets_.make_set(cpx_->key(sh));
       int dim_simplex = cpx_->dimension(sh);
-      switch (dim_simplex) {
-        case 0:
-          vertices.push_back(idx_fil);
-          break;
-        case 1:
-          update_cohomology_groups_edge(sh);
-          break;
-        default:
-          update_cohomology_groups(sh, dim_simplex);
-          break;
+      if (is_simplicial_and_starting_from_dim_0){
+        switch (dim_simplex) {
+          case 0:
+            vertices.push_back(idx_fil);
+            break;
+          case 1:
+            update_cohomology_groups_edge(sh);
+            break;
+          default:
+            update_cohomology_groups(sh, dim_simplex);
+            break;
+        }
+      } else {
+        update_cohomology_groups(sh, dim_simplex);
       }
     }
     // Compute infinite intervals of dimension 0

--- a/multipers/multi_parameter_rank_invariant/hilbert_function.h
+++ b/multipers/multi_parameter_rank_invariant/hilbert_function.h
@@ -14,6 +14,8 @@
 #include <utility>  // std::pair
 #include <vector>
 
+#include "../gudhi/mma_interface_coh.h"
+
 namespace Gudhi::multiparameter::hilbert_function {
 
 // TODO : this function is ugly
@@ -505,8 +507,12 @@ inline void compute_2d_hilbert_surface(
       }
       barcodes = slicer.get_barcode();
     } else {
-      slicer.template compute_persistence<false>();  // BUG : cannot put this to
-                                                     // true ??
+      //TODO: correct problem with R to only have slicer.template compute_persistence<true>();
+      if constexpr (std::is_same_v<PersBackend, Gudhi::multiparameter::interface::Persistence_backend_cohomology<Structure> >){
+        slicer.template compute_persistence<true>();
+      } else {
+        slicer.template compute_persistence<false>();  // BUG : cannot put this to true ??
+      }
       barcodes = slicer.get_barcode();
     }
     index_type degree_index = 0;

--- a/multipers/multi_parameter_rank_invariant/hilbert_function.h
+++ b/multipers/multi_parameter_rank_invariant/hilbert_function.h
@@ -14,8 +14,6 @@
 #include <utility>  // std::pair
 #include <vector>
 
-#include "../gudhi/mma_interface_coh.h"
-
 namespace Gudhi::multiparameter::hilbert_function {
 
 // TODO : this function is ugly
@@ -498,23 +496,16 @@ inline void compute_2d_hilbert_surface(
       std::cout << "]" << std::endl;
     }
     using bc_type = typename interface::Truc<PersBackend, Structure, Filtration>::split_barcode;
-    bc_type barcodes;
     if constexpr (PersBackend::is_vine) {
       if (!slicer.has_persistence()) [[unlikely]] {
         slicer.compute_persistence();
       } else {
         slicer.vineyard_update();
       }
-      barcodes = slicer.get_barcode();
     } else {
-      //TODO: correct problem with R to only have slicer.template compute_persistence<true>();
-      if constexpr (std::is_same_v<PersBackend, Gudhi::multiparameter::interface::Persistence_backend_cohomology<Structure> >){
-        slicer.template compute_persistence<true>();
-      } else {
-        slicer.template compute_persistence<false>();  // BUG : cannot put this to true ??
-      }
-      barcodes = slicer.get_barcode();
+      slicer.template compute_persistence<true>();
     }
+    bc_type barcodes = slicer.get_barcode();
     index_type degree_index = 0;
     for (auto degree : degrees) {  // TODO range view cartesian product
       const auto &barcode = barcodes[degree];

--- a/multipers/multi_parameter_rank_invariant/rank_invariant.h
+++ b/multipers/multi_parameter_rank_invariant/rank_invariant.h
@@ -228,7 +228,7 @@ inline void compute_2d_rank_invariant_of_elbow(
     }
     barcodes = slicer.get_barcode();
   } else {
-    slicer.template compute_persistence<false>();  // PUT THAT TO TRUE...
+    slicer.template compute_persistence<true>();
     barcodes = slicer.get_barcode();
   }
 

--- a/multipers/simplex_tree_multi.pxd
+++ b/multipers/simplex_tree_multi.pxd
@@ -100,7 +100,7 @@ cdef extern from "Simplex_tree_multi_interface.h" namespace "Gudhi::multiparamet
     void set_keys_to_enumerate() nogil const
     int get_key(const simplex_type) nogil
     void set_key(simplex_type, int) nogil
-    void fill_lowerstar(const F&, int) nogil
+    void fill_lowerstar(const F&, int) except+ nogil
     simplex_list get_simplices_of_dimension(int) nogil
     edge_list get_edge_list() nogil
     # euler_char_list euler_char(const vector[filtration_type]&) nogil

--- a/multipers/slicer.pxd.tp
+++ b/multipers/slicer.pxd.tp
@@ -65,8 +65,8 @@ cdef extern from "Persistence_slices_interface.h":
       int prune_above_dimension(int) except + nogil 
 
       vector[{{D['C_VALUE_TYPE']}}] get_one_filtration()
-      void compute_persistence(vector[bool]) nogil
-      void compute_persistence() nogil
+      void compute_persistence(vector[bool]) except+ nogil
+      void compute_persistence() except+ nogil
       uint32_t num_generators() nogil
       uint32_t num_parameters() nogil
       string to_str() nogil


### PR DESCRIPTION
The cohomology interface should be able to ignore values at -1 in the permutation now, such that `slicer.template compute_persistence<true>();` can be used.
And to enable cohomology also for non simplicial filtration, I added a bool as argument in `compute_persistent_cohomology`, which I put to `false` in the interface. You should see, if you want to make `true` possible.